### PR TITLE
:recycle: refactor to remove the bus and delay from the driver struct

### DIFF
--- a/examples/stm32f3-discovery-example.rs
+++ b/examples/stm32f3-discovery-example.rs
@@ -34,7 +34,7 @@ fn main() -> ! {
             .into_af4_open_drain(&mut gpiob.moder, &mut gpiob.otyper, &mut gpiob.afrl);
     scl.internal_pull_up(&mut gpiob.pupdr, true);
     sda.internal_pull_up(&mut gpiob.pupdr, true);
-    let i2c = hal::i2c::I2c::new(
+    let mut i2c = hal::i2c::I2c::new(
         dp.I2C1,
         (scl, sda),
         40.kHz().try_into().unwrap(),
@@ -42,12 +42,10 @@ fn main() -> ! {
         &mut rcc.apb1,
     );
 
-    let delay = hal::delay::Delay::new(cp.SYST, clocks);
+    let mut delay = hal::delay::Delay::new(cp.SYST, clocks);
 
     let mut led_matrix = grove_matrix_led_my9221_rs::My9221LedMatrix::new(
         grove_matrix_led_my9221_rs::DEFAULT_ADDRESS,
-        i2c,
-        delay,
     );
 
     let mut emoji_num = 0;
@@ -55,8 +53,8 @@ fn main() -> ! {
     const DELAY: u16 = 5_000u16;
 
     loop {
-        led_matrix.display_emoji(emoji_num, DELAY, true);
-        led_matrix.delay_ms(DELAY.into());
+        led_matrix.display_emoji(&mut i2c, emoji_num, DELAY, true);
+        delay.delay_ms(DELAY);
         emoji_num = (emoji_num + 1) % 32;
     }
 }


### PR DESCRIPTION
Removing the bus and delay from the driver struct
Passing them to function calls as ref mut pushes away the need of synchronization.
It seems more reasonable to let this be handled by the plateform

Fix #9 